### PR TITLE
Feat/add cli for future development

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,27 +1,30 @@
 {
   "name": "shadow-core",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "shadow-core",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "hasInstallScript": true,
       "license": "GPL-3.0",
       "dependencies": {
         "axios": "^1.8.1",
+        "commander": "^13.1.0",
         "discord.js": "^14.8.0",
         "glob": "^11.0.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.23.0",
         "@types/axios": "^0.14.4",
+        "@types/commander": "^2.12.0",
         "@typescript-eslint/eslint-plugin": "^8.27.0",
         "@typescript-eslint/parser": "^8.27.0",
         "eslint": "^9.23.0",
         "eslint-define-config": "^2.1.0",
         "globals": "^16.0.0",
+        "install": "^0.13.0",
         "ts-node": "^10.9.1",
         "typescript": "^5.0.0",
         "typescript-eslint": "^8.27.0"
@@ -577,6 +580,16 @@
         "axios": "*"
       }
     },
+    "node_modules/@types/commander": {
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/@types/commander/-/commander-2.12.0.tgz",
+      "integrity": "sha512-DDmRkovH7jPjnx7HcbSnqKg2JeNANyxNZeUvB0iE+qKBLN+vzN5iSIwt+J2PFSmBuYEut4mgQvI/fTX9YQH/vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -1048,6 +1061,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/concat-map": {
@@ -1839,6 +1861,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/install": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/install/-/install-0.13.0.tgz",
+      "integrity": "sha512-zDml/jzr2PKU9I8J/xyZBQn8rPCAY//UOYNmR01XwNwyfhEWObo2SWfSl1+0tm1u6PhxLwDnfsT/6jB7OUxqFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-extglob": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "type": "module",
+  "bin": {
+    "shadow-core": "./dist/src/cli/cli.js"
+  },
   "scripts": {
     "build": "tsc",
     "prepublishOnly": "npm run build",
@@ -37,17 +40,20 @@
   },
   "dependencies": {
     "axios": "^1.8.1",
+    "commander": "^13.1.0",
     "discord.js": "^14.8.0",
     "glob": "^11.0.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.23.0",
     "@types/axios": "^0.14.4",
+    "@types/commander": "^2.12.0",
     "@typescript-eslint/eslint-plugin": "^8.27.0",
     "@typescript-eslint/parser": "^8.27.0",
     "eslint": "^9.23.0",
     "eslint-define-config": "^2.1.0",
     "globals": "^16.0.0",
+    "install": "^0.13.0",
     "ts-node": "^10.9.1",
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.27.0"

--- a/package.json
+++ b/package.json
@@ -4,12 +4,12 @@
   "description": "A modular core framework for Discord bot development, providing commands, buttons, menus, middleware, and more.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "type": "module",
   "bin": {
-    "shadow-core": "./dist/src/cli/cli.js"
+    "shadow-core": "dist/cli/cli.js"
   },
   "scripts": {
     "build": "tsc",
+    "postbuild": "node ./scripts/add-shebang.js",
     "prepublishOnly": "npm run build",
     "test": "echo \"No tests configured yet\" && exit 0",
     "type-check": "tsc --noEmit",

--- a/scripts/add-shebang.js
+++ b/scripts/add-shebang.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+const cliJsPath = path.join(__dirname, '../dist/cli/cli.js');
+const shebang = '#!/usr/bin/env node\n';
+
+fs.readFile(cliJsPath, 'utf8', (err, data) => {
+  if (err) {
+    console.error('Error reading cli.js:', err);
+    return;
+  }
+
+  if (!data.startsWith(shebang)) {
+    fs.writeFile(cliJsPath, shebang + data, 'utf8', (err) => {
+      if (err) {
+        console.error('Error adding shebang to cli.js:', err);
+      } else {
+        console.log('Shebang added to cli.js');
+      }
+    });
+  }
+});

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -1,0 +1,14 @@
+import { Command } from "commander";
+import { readPackageJson } from "../utils/general.js";
+import exampleCommand from "./commands/example.js";
+
+const program = new Command();
+const version = readPackageJson().version;
+
+program.version(version).description("ShadowCore CLI");
+
+// Define your commands here
+// Example command
+program.addCommand(exampleCommand)
+
+program.parse(process.argv);

--- a/src/cli/commands/example.ts
+++ b/src/cli/commands/example.ts
@@ -1,0 +1,10 @@
+import { Command } from "commander";
+
+const exampleCommand = new Command("example")
+    .description("An example command")
+    .action(() => {
+        console.log("This is an example command.");
+    }
+);
+
+export default exampleCommand;

--- a/src/utils/general.ts
+++ b/src/utils/general.ts
@@ -1,0 +1,8 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+export function readPackageJson(): Record<string, any> {
+    const packageJsonPath = join(process.cwd(), 'package.json');
+    const fileContent = readFileSync(packageJsonPath, 'utf-8');
+    return JSON.parse(fileContent);
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,3 +2,4 @@ export * from "./logger";
 export * from "./request";
 export * from "./taskScheduler";
 export * from "./apiCache";
+export * from "./general";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,16 @@
 {
   "compilerOptions": {
-    "target": "ES6",                         
-    "module": "CommonJS",                     
+    "target": "ES2020",                         
+    "module": "ESNext",    
+    "moduleResolution": "node",                 
     "declaration": true,                       
     "outDir": "./dist",                       
     "strict": true,                           
     "esModuleInterop": true,                  
     "skipLibCheck": true,                     
-    "forceConsistentCasingInFileNames": true  
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "__tests__"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,16 +1,15 @@
 {
   "compilerOptions": {
-    "target": "ES2020",                         
-    "module": "ESNext",    
-    "moduleResolution": "node",                 
-    "declaration": true,                       
-    "outDir": "./dist",                       
-    "strict": true,                           
-    "esModuleInterop": true,                  
-    "skipLibCheck": true,                     
+    "target": "ES2020",
+    "module": "CommonJS",       // This ensures `require`/`module.exports` syntax
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "__tests__"]


### PR DESCRIPTION
## 📝 Description
This PR implements the necessary changes to make the ShadowCore CLI functional and ready for usage via the `shadow-core` command. It resolves issues with the CLI entry point, ensuring that it works correctly after being installed globally or linked locally. This update ensures that the command can now execute commands as expected from the command line interface.

## 🔍 Related Issues
N/A

## 🚀 Changes Made
- [x] New feature ✨

## ✅ Testing Steps
<!-- Provide instructions for testing your changes. Include commands, expected behavior, and test cases if applicable. -->
1. Ensure you have `shadow-core` linked or installed globally (`npm link` or `npm install -g`).
2.  Run `npx shadow-core <command>` to test the CLI command
     - Example: `npx shadow-core example` should trigger the expected behavior for the `example` command.
3. Verify that the output matches the expected results and no errors are present.

## 🔒 Security Considerations
No new security concerns identified. However, make sure the CLI has appropriate permissions when executed globally or locally.

## 📸 Screenshots / Logs (if applicable)
N/A

## ⏳ Checklist
- [x] My code follows the project coding style.
- [x] I have run tests to verify my changes.
- [x] I have updated the documentation if needed.
- [ ] My changes do not introduce new vulnerabilities.
- [x] This PR is ready for review.

---

### 🚀 Additional Notes
- The CLI now includes basic functionality to support `npx shadow-core` commands.
- Future enhancements may include more complex commands and additional options for users.
