### PR TITLE
feat(utils): add class-based TaskScheduler with immediate execution support

### DIFF
--- a/src/types/task.ts
+++ b/src/types/task.ts
@@ -1,0 +1,6 @@
+export type Task = {
+  name: string;
+  interval: number;
+  timer: NodeJS.Timeout;
+  callback: () => void;
+};

--- a/src/utils/taskScheduler.ts
+++ b/src/utils/taskScheduler.ts
@@ -1,4 +1,53 @@
-export function scheduleTask(taskName: string, interval: number, callback: () => void) {
-    console.log(`🕒 Scheduled Task: ${taskName} (Runs every ${interval / 1000}s)`);
-    setInterval(callback, interval)
+import { Task } from "../types/task";
+
+export class TaskScheduler {
+  private tasks = new Map<string, Task>();
+
+  schedule(
+    name: string,
+    interval: number,
+    callback: () => void,
+    immediate = false
+  ): void {
+    if (this.tasks.has(name)) {
+      console.warn(`⚠️ Task "${name}" is already scheduled.`);
+      return;
+    }
+
+    console.log(`🕒 Scheduled Task: ${name} (every ${interval / 1000}s)`);
+
+    if (immediate) {
+      try {
+        callback();
+      } catch (err) {
+        console.error(`❌ Initial run of task "${name}" failed:`, err);
+      }
+    }
+
+    const timer = setInterval(() => {
+      try {
+        callback();
+      } catch (err) {
+        console.error(`❌ Task "${name}" error:`, err);
+      }
+    }, interval);
+
+    this.tasks.set(name, { name, interval, timer, callback });
+  }
+
+  cancel(name: string): void {
+    const task = this.tasks.get(name);
+    if (!task) return console.warn(`⚠️ Task "${name}" not found.`);
+    clearInterval(task.timer);
+    this.tasks.delete(name);
+    console.log(`🛑 Cancelled Task: ${name}`);
+  }
+
+  list(): string[] {
+    return Array.from(this.tasks.keys());
+  }
+
+  has(name: string): boolean {
+    return this.tasks.has(name);
+  }
 }


### PR DESCRIPTION
## 📝 Description

This PR introduces a class-based version of the internal `TaskScheduler` utility in `@shadow-dev/core`. It replaces the prior function-based implementation with a more extensible and reusable approach.

Key enhancements:
- Maintains a registry of active tasks to prevent duplicates
- Supports clean task cancellation and lookup
- Adds optional `immediate` flag to run the task once upon registration
- Prepares the utility for future extensibility (pause/resume/restart)

---

## 🔍 Related Issues

N/A

---

## 🚀 Changes Made

- [x] New feature ✨  
- [ ] Bug fix 🐛  
- [ ] Code refactor 🔧  
- [ ] Documentation update 📖  
- [ ] Security improvement 🔒  
- [ ] Other: _Utility expansion_

---

## ✅ Testing Steps

1. Register a repeating task using `TaskScheduler.schedule()`  
2. Confirm `immediate: true` triggers first run instantly  
3. Use `TaskScheduler.cancel()` and confirm log + interval stop  
4. Attempt to double-schedule a task and verify warning

---

## 🔒 Security Considerations

- No external dependencies introduced  
- Internal-only class, no user token or file access  
- Safe to expose in public core package

---

## 📸 Screenshots / Logs (if applicable)

N/A — CLI logs only:
```
🕒 Scheduled Task: cleanup (every 10s)
🧹 Running cleanup...
🛑 Cancelled Task: cleanup
```

---

## ⏳ Checklist

- [x] My code follows the project coding style  
- [x] I have run tests to verify my changes  
- [ ] I have updated the documentation if needed  
- [x] My changes do not introduce new vulnerabilities  
- [x] This PR is ready for review  

---

### 🚀 Additional Notes

This sets the foundation for more advanced internal tools like a timed job system or Redis-backed distributed scheduler if needed in the future.
